### PR TITLE
Major: support for .NET 9

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "SimpleOTP",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -19,7 +19,7 @@ on:
       - '.assets/*'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -66,8 +66,16 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Build project
+      run: dotnet build
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -2,7 +2,7 @@ name: "Build workflow"
 
 on:
   push:
-    branches: [ "main", "next", "net8.0", "net9.0" ]
+    branches: [ "main", "next" ]
     paths-ignore:
       - "**.md"
       - "LICENSE"
@@ -12,7 +12,7 @@ on:
       - ".devcontainer/*"
       - "!.github/workflows/pr-workflow.yml"
   pull_request:
-    branches: [ "main", "next", "net8.0", "net9.0" ]
+    branches: [ "main", "next" ]
     paths-ignore:
       - "**.md"
       - "LICENSE"

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -2,7 +2,7 @@ name: "Build workflow"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next", "net8.0", "net9.0" ]
     paths-ignore:
       - "**.md"
       - "LICENSE"
@@ -12,7 +12,7 @@ on:
       - ".devcontainer/*"
       - "!.github/workflows/pr-workflow.yml"
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "next", "net8.0", "net9.0" ]
     paths-ignore:
       - "**.md"
       - "LICENSE"
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - run: dotnet restore
       - run: dotnet build --no-restore
@@ -46,7 +46,7 @@ jobs:
         with:
           name: SimpleOTP
           path: libraries/SimpleOTP/bin/Debug/EugeneFox.SimpleOTP*.*nupkg
-          
+
       - name: Drop SimpleOTP.DependencyInjection
         uses: actions/upload-artifact@main
         with:

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - run: dotnet restore
       - run: dotnet pack

--- a/SimpleOTP.Tests/SimpleOTP.Tests.csproj
+++ b/SimpleOTP.Tests/SimpleOTP.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="NUnit" Version="4.2.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 	</ItemGroup>

--- a/libraries/SimpleOTP.DependencyInjection/SimpleOTP.DependencyInjection.csproj
+++ b/libraries/SimpleOTP.DependencyInjection/SimpleOTP.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/libraries/SimpleOTP.DependencyInjection/SimpleOTP.DependencyInjection.csproj
+++ b/libraries/SimpleOTP.DependencyInjection/SimpleOTP.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,7 +9,7 @@
 
 	<PropertyGroup>
 		<PackageId>EugeneFox.SimpleOTP.DependencyInjection</PackageId>
-		<Version>8.0.0.0</Version>
+		<Version>9.0.0.0</Version>
 		<Authors>Eugene Fox</Authors>
 		<Copyright>Copyright © Eugene Fox 2024</Copyright>
 		<NeutralLanguage>en-US</NeutralLanguage>
@@ -37,7 +37,7 @@
 			service in your application.
 		</Description>
 		<PackageReleaseNotes>
-			Initial release. See README.md for details.
+			New major version for .NET 9
 		</PackageReleaseNotes>
 	</PropertyGroup>
 
@@ -57,9 +57,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.*" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.*" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-			Version="8.0.*" />
+			Version="9.0.*" />
 	</ItemGroup>
 
 </Project>

--- a/libraries/SimpleOTP/Otp.cs
+++ b/libraries/SimpleOTP/Otp.cs
@@ -2,8 +2,6 @@ using System.Security.Cryptography;
 
 namespace SimpleOTP;
 
-// TODO: Add tests
-
 /// <summary>
 /// Represents an abstract class for generating and validating One-Time Passwords (OTP).
 /// </summary>

--- a/libraries/SimpleOTP/SimpleOTP.csproj
+++ b/libraries/SimpleOTP/SimpleOTP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/libraries/SimpleOTP/SimpleOTP.csproj
+++ b/libraries/SimpleOTP/SimpleOTP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -14,7 +14,7 @@
 
 	<PropertyGroup>
 		<PackageId>EugeneFox.SimpleOTP</PackageId>
-		<Version>8.0.0.0</Version>
+		<Version>9.0.0.0</Version>
 		<Authors>Eugene Fox</Authors>
 		<Copyright>Copyright © Eugene Fox 2024</Copyright>
 		<NeutralLanguage>en-US</NeutralLanguage>
@@ -35,7 +35,7 @@
 			Feature-rich, fast, and customizable library for implementation TOTP/HOTP authenticators and validators.
 		</Description>
 		<PackageReleaseNotes>
-			(BREAKING CHANGE) Complete overhaul of the library. See https://github.com/XFox111/SimpleOTP/releases/tag/2.0.0 for more details.
+			New major version for .NET 9
 		</PackageReleaseNotes>
 	</PropertyGroup>
 


### PR DESCRIPTION
## Description
Since Microsoft released a new .NET 9 STS, we add its support as well.

## Lifecycle
Official End-of-Life dates for target frameworks are:
- .NET 8 EOL: November 2026
- .NET 9 EOL: May 2026

While support for .NET 9 ends sooner than one for .NET 8, to keep versioning simple, we will keep supporting SimpleOTP 9.x and .NET 9 up until .NET 8 EOL (November 2026).

If this will be proven to be an optimal strategy, the same cycle will be applied for v10 and v11

### Changelog
- Added `net9.0` to `TargetFrameworks`
- Updated `SimpleOTP.Tests` dependencies

Resolves: #25